### PR TITLE
Add support for the new Digital Link Node

### DIFF
--- a/src/l2Mps_mps.cpp
+++ b/src/l2Mps_mps.cpp
@@ -84,8 +84,9 @@ IMpsNode::IMpsNode(Path root)
         throw std::runtime_error("Could not read the slot number\n");
 
     // For Link Node, instantiate a MpsLinkNode object.
-    // Link nodes are BLM or MPS app types, installed in slot 2.
-    if ( ( 2 == slotNumber ) & ((!appTypeName.compare("BLM")) | (!appTypeName.compare("MPS_6CH")) | (!appTypeName.compare("MPS_24CH"))) )
+    // Link nodes are BLM, Digital Nodes, or MPS app types, installed in slot 2.
+    if ( ( 2 == slotNumber ) & ((!appTypeName.compare("BLM")) | (!appTypeName.compare("MPS_6CH")) | \
+        (!appTypeName.compare("MPS_24CH")) | (!appTypeName.compare("MPS_DN"))) )
     {
         std::cout << "    > This is a Mps Link Node" << std::endl;
         mpsLinkNode = IMpsLinkNode::create(root);

--- a/src/l2Mps_mps.cpp
+++ b/src/l2Mps_mps.cpp
@@ -102,6 +102,8 @@ IMpsNode::IMpsNode(Path root)
             amc[i] = IMpsBcm::create(mpsRoot, i);
         else if ((!appTypeName.compare("BLM")) | (!appTypeName.compare("MPS_6CH")) | (!appTypeName.compare("MPS_24CH")))
             amc[i] = IMpsBlm::create(mpsRoot, i);
+        else if (!appTypeName.compare("MPS_DN"))
+            ; // The Digital AMC does not contain any settings. So, we let the amc object empty here.
         else
             // Throw and error when the application type is not supported
             throw std::runtime_error("Unsupported application type");

--- a/src/l2Mps_mps.h
+++ b/src/l2Mps_mps.h
@@ -71,7 +71,8 @@ static std::map<int, std::string> appTypeList = {
     {100,   "BPM"},
     {101,   "BPM"},
     {120,   "MPS_24CH"},
-    {121,   "MPS_6CH"}
+    {121,   "MPS_6CH"},
+    {122,   "MPS_DN"}
 };
 
 // Number of AMC bays on a carrier

--- a/src/test/blm.cpp
+++ b/src/test/blm.cpp
@@ -79,7 +79,7 @@ int main(int argc, char **argv)
 
         std::string appType(mpsNode->getAppType().second);
         std::cout << "This application type is " << appType << std::endl;
-        if ( appType.compare("BLM") & appType.compare("MPS_6CH") & appType.compare("MPS_24CH") )
+        if ( !!appType.compare("BLM") & !!appType.compare("MPS_6CH") & !!appType.compare("MPS_24CH") )
         {
             std::cout << "ERROR: This is not a BLM application. Aborting." << std::endl;
             return 1;

--- a/src/test/mps.cpp
+++ b/src/test/mps.cpp
@@ -122,8 +122,8 @@ void Tester::mpsInfoReceiver(mps_infoData_t info)
         std::cout << std::endl;
         std::cout << "Link node status: " << std::endl;
         std::cout << "-------------------" << std::endl;
-        printPair( "  Soft input values      ", info.lnData.softInputData.inputWord, true );
-        printPair( "  Soft input error values", info.lnData.softInputData.errorWord, true );
+        printPair( "Soft input values", info.lnData.softInputData.inputWord, true, 2, 24 );
+        printPair( "Soft input error values", info.lnData.softInputData.errorWord, true, 2, 24 );
         std::cout << "-------------------" << std::endl;
 
             std::cout << "=============================" << std::endl;


### PR DESCRIPTION
This PR add support for the new type of Link Node which uses only digital AMC boards.

https://jira.slac.stanford.edu/browse/ESLMPS-97

This PR also fixes a couple of small bugs in the example applications.