### PR TITLE
Change Idle Table threshold table support initialization

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,12 @@
 Release notes for the SLAC LCLS2 HPS MPS Driver.
 
 ## Releases:
+* __R3.8.0__: 2022-05-03 J. Mock
+  * Change src/l2Mps_thr.cpp so that idl table threshold support is built for all applications.  
+    Method of using idle table enable bit as a deciding factor for whether to build support or not
+    does not work since this table can be enabled / disabled at run time.  Other tables are enables / 
+    disabled at build time
+
 * __R3.7.0__: 2021-08-18 J. Vasquez
   * Add support for the Fast Wire Scanner (FWS) application type. This type of application
     doesn't have any application specific settings.

--- a/src/l2Mps_thr.cpp
+++ b/src/l2Mps_thr.cpp
@@ -58,7 +58,7 @@ IThrChannel::IThrChannel(Path mpsRoot, uint8_t channel)
     if (thrChInfo.lcls1En.first && thrChInfo.lcls1En.second)
         thrScalvals.data.insert( std::make_pair( thr_table_t{{0,0}}, createTableScalVal("lcls1Thr/") ) );
 
-    if ( thrChInfo.idleEn.first && thrChInfo.idleEn.second )
+    if ( thrChInfo.idleEn.first )
         thrScalvals.data.insert( std::make_pair( thr_table_t{{1,0}}, createTableScalVal("idleThr/") ) );
 
     if ( thrChInfo.count.first )


### PR DESCRIPTION
* Make idle table support present for all applications instead of relying on the enabled bit