### PR TITLE
Allow host arch to be automatically detected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 -include config.mak
+-include $(CPSW_DIR)/src/arch-detect.mak
+
+HARCH?=$(HOST_ARCH)
 
 SRCDIR = src
 
@@ -8,7 +11,7 @@ TOPTARGETS = all clean install uninstall
 
 $(TOPTARGETS):
 	@printf '\n========== Building for $(HARCH) ==========\n\n'
-	H_VERSION=$(HARCH) $(MAKE) -C $(SRCDIR) $(MAKECMDGOALS)
+	HARCH=$(HARCH) $(MAKE) -C $(SRCDIR) $(MAKECMDGOALS)
 	@for br_arch in $(BR_ARCHES); do \
 		printf "\n========== Building for $$br_arch ==========\n\n"; \
 		BR_VERSION=$$br_arch $(MAKE) -C $(SRCDIR) $(MAKECMDGOALS); \

--- a/config.mak
+++ b/config.mak
@@ -7,7 +7,7 @@ LIB_NAME = l2Mps
 ### Arch Versions ###
 #####################
 # Host version
-HARCH      = rhel6
+#HARCH      = rhel6
 # Buildroot versions
 BR_ARCHES += buildroot-2019.08
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@ ifdef BR_VERSION
 	TARCH    = $(BR_VERSION)-x86_64
 else
 	CXX    = g++
-	TARCH  = $(H_VERSION)-x86_64
+	TARCH  = $(HARCH)
 endif
 
 OBJDIR   = O.$(TARCH)

--- a/src/l2Mps_base.h
+++ b/src/l2Mps_base.h
@@ -22,7 +22,9 @@
  * ----------------------------------------------------------------------------
 **/
 
+#ifndef _GLIBCXX_USE_NANOSLEEP
 #define _GLIBCXX_USE_NANOSLEEP    // Workaround to use std::this_thread::sleep_for
+#endif
 
 #include <thread>
 #include <chrono>

--- a/src/l2Mps_mps.cpp
+++ b/src/l2Mps_mps.cpp
@@ -267,4 +267,5 @@ const uint64_t IMpsNode::loadConfigFile(std::string fileName) const
     std::cout << "Loading MPS application configuration file " << fileName << "..." << std::endl;
     uint64_t nEntriesLoaded = cpswRoot->loadConfigFromYamlFile(fileName.c_str());
     std::cout << "Done!. " << unsigned(nEntriesLoaded) << " entries were loaded." << std::endl;
+    return nEntriesLoaded;
 }

--- a/src/l2Mps_mps.h
+++ b/src/l2Mps_mps.h
@@ -23,7 +23,9 @@
  * ----------------------------------------------------------------------------
 **/
 
+#ifndef _GLIBCXX_USE_NANOSLEEP
 #define _GLIBCXX_USE_NANOSLEEP    // Workaround to use std::this_thread::sleep_for
+#endif
 
 #include <stdio.h>
 #include <iostream>


### PR DESCRIPTION
Relies on some changes to CPSW, so marking as draft until a new release of that becomes available.

Part of ECS-4159

Other changes:
* Fix some build warnings
* Fix test compilation on certain RHEL7 machines. `-static` may not work if the proper development packages are not installed. dev-rhel7 doesn't have them, whereas aird-b50-srv01 does. So let's just use a normal shared build on RHEL7 hosts for these tests.